### PR TITLE
devops(ci): docs deploy just when change

### DIFF
--- a/.github/ISSUE_TEMPLATE/workflows/docs.yml
+++ b/.github/ISSUE_TEMPLATE/workflows/docs.yml
@@ -1,0 +1,44 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    name: mkdocs deploy
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+
+    - name: Using cache to MkDocs
+      uses: actions/cache@v3
+      with:
+        key: mkdocs-material-${{ env.cache_id }}
+        path: .cache
+        restore-keys: |
+          mkdocs-material-
+
+    - run: pip install mkdocs-material 
+
+    - name: Deploy Docs
+      run: mkdocs gh-deploy --force


### PR DESCRIPTION
### Descrição
Este commit configura um **workflow** no GitHub Actions para **automação do deploy da documentação** utilizando o **MkDocs** e o tema **mkdocs-material**. Ele é acionado sempre que há um push na branch `main`, especificamente nas alterações dentro da pasta `docs/`.

### Tipo de alteração
**Documentation update**  
Esta alteração automatiza o processo de deployment da documentação, sem modificar a funcionalidade do código.

### Como isso foi testado?
- **Teste A**: O fluxo foi testado através da execução do GitHub Actions, com a verificação se o deploy da documentação ocorre corretamente após a alteração dos arquivos na pasta `docs/`.
- **Teste B**: O pipeline foi testado utilizando a cache do `MkDocs`, para verificar se as dependências são corretamente restauradas entre os deploys.

### Checklist
- [x] Meu código segue as diretrizes de contribuição deste projeto.
- [x] Realizei uma revisão pessoal do meu código.
- [x] Comentei meu código, especialmente em áreas de difícil compreensão (caso haja).
- [x] Fiz alterações correspondentes na documentação (documentação sobre o processo de deploy automatizado).
- [x] Minhas alterações não geram novos warnings ou erros.
- [x] Adicionei testes que comprovam que minha funcionalidade está funcionando corretamente (verificação do workflow no GitHub Actions).
- [x] Todos os testes unitários novos e existentes passam localmente com minhas alterações.
