### PR TITLE
test: add unit tests for controllers and category creation use cases

### DIFF
--- a/backend/test/category/controllers/createCategoryController.spec.ts
+++ b/backend/test/category/controllers/createCategoryController.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CreateCategoryController } from "@/main/controllers/category/createCategoryController";
+import { CreateCategoryUseCase } from "@/application/useCases/category/createCategoryUseCase";
+import { InMemoryCategoryRepository } from "@/infrastructure/database/inMemoryRepository/inMemoryCategoryRepository";
+
+describe("CreateCategoryController", () => {
+  let createCategoryController: CreateCategoryController;
+  let createCategoryUseCase: CreateCategoryUseCase;
+  let inMemoryCategoryRepository: InMemoryCategoryRepository;
+
+  beforeEach(() => {
+    inMemoryCategoryRepository = new InMemoryCategoryRepository();
+    createCategoryUseCase = new CreateCategoryUseCase(
+      inMemoryCategoryRepository,
+    );
+    createCategoryController = new CreateCategoryController(
+      createCategoryUseCase,
+    );
+  });
+
+  it("should create a category and return a created response", async () => {
+    // Arrange
+    const httpRequest = {
+      body: {
+        name: "New Category",
+        userId: 1,
+      },
+    };
+
+    // Act
+    const httpResponse = await createCategoryController.handle(httpRequest);
+
+    const responseBody = {
+      message: "Category created successfully",
+      category: {
+        name: httpRequest.body.name,
+      },
+    };
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(201);
+    expect(httpResponse.body).toEqual(responseBody);
+  });
+
+  it("should return a bad request when validation fails", async () => {
+    // Arrange
+    const httpRequest = {
+      body: {
+        name: "",
+        userId: 1,
+      },
+    };
+
+    // Act
+    const httpResponse = await createCategoryController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(400);
+    expect(httpResponse.body).toEqual("Name cannot be empty");
+  });
+
+  it("should return 'Category already exists' if the category already exists", async () => {
+    // Arrange
+    const httpRequest = {
+      body: {
+        name: "Existing Category",
+        userId: 1,
+      },
+    };
+    await createCategoryController.handle(httpRequest);
+
+    // Act
+    const httpResponse = await createCategoryController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(400);
+    expect(httpResponse.body).toEqual("Category already exists");
+  });
+
+  it("should return a server error if an error was thrown", async () => {
+    // Arrange
+    const httpRequest = {
+      body: {
+        name: "New Category",
+        userId: 1,
+      },
+    };
+    vi.spyOn(createCategoryUseCase, "execute").mockRejectedValueOnce(
+      new Error(""),
+    );
+
+    // Act
+    const httpResponse = await createCategoryController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(500);
+    expect(httpResponse.body).toEqual("Something went wrong.");
+  });
+});

--- a/backend/test/category/controllers/getCategoriesByUserController.spec.ts
+++ b/backend/test/category/controllers/getCategoriesByUserController.spec.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GetCategoriesByUserController } from "@/main/controllers/category/getCategoriesByUserController";
+import { GetCategoriesByUserUseCase } from "@/application/useCases/category/getCategoriesUseCase";
+import { InMemoryCategoryRepository } from "@/infrastructure/database/inMemoryRepository/inMemoryCategoryRepository";
+
+describe("GetCategoriesByUserController", () => {
+  let getCategoriesByUserController: GetCategoriesByUserController;
+  let getCategoriesByUserUseCase: GetCategoriesByUserUseCase;
+  let inMemoryCategoryRepository: InMemoryCategoryRepository;
+
+  beforeEach(() => {
+    inMemoryCategoryRepository = new InMemoryCategoryRepository();
+    getCategoriesByUserUseCase = new GetCategoriesByUserUseCase(
+      inMemoryCategoryRepository,
+    );
+    getCategoriesByUserController = new GetCategoriesByUserController(
+      getCategoriesByUserUseCase,
+    );
+  });
+
+  it("should return categories for a valid user ID", async () => {
+    // Arrange
+    const httpRequest = {
+      userId: 1,
+    };
+
+    await inMemoryCategoryRepository.createCategory({
+      name: "Category 1",
+      userId: 1,
+    });
+
+    // Act
+    const httpResponse =
+      await getCategoriesByUserController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(200);
+    expect(httpResponse.body).toEqual({
+      message: "Category found successfully",
+      category: [{ name: "Category 1" }],
+    });
+  });
+
+  it("should return bad request if user ID is not provided", async () => {
+    // Arrange
+    const httpRequest = {};
+
+    // Act
+    const httpResponse =
+      await getCategoriesByUserController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(400);
+    expect(httpResponse.body).toEqual("User ID is required");
+  });
+
+  it("should return server error if an exception is thrown", async () => {
+    // Arrange
+    const httpRequest = {
+      userId: 1,
+    };
+    vi.spyOn(getCategoriesByUserUseCase, "execute").mockRejectedValueOnce(
+      new Error(""),
+    );
+
+    // Act
+    const httpResponse =
+      await getCategoriesByUserController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(500);
+    expect(httpResponse.body).toEqual("Something went wrong.");
+  });
+});

--- a/backend/test/category/useCases/createCategoryUseCase.spec.ts
+++ b/backend/test/category/useCases/createCategoryUseCase.spec.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { CreateCategoryUseCase } from "@/application/useCases/category/createCategoryUseCase";
+import { InMemoryCategoryRepository } from "@/infrastructure/database/inMemoryRepository/inMemoryCategoryRepository";
+
+describe("CreateCategoryUseCase", () => {
+  let createCategoryUseCase: CreateCategoryUseCase;
+  let inMemoryCategoryRepository: InMemoryCategoryRepository;
+
+  beforeEach(() => {
+    inMemoryCategoryRepository = new InMemoryCategoryRepository();
+    createCategoryUseCase = new CreateCategoryUseCase(
+      inMemoryCategoryRepository,
+    );
+  });
+
+  it("should create a new category if it does not exist", async () => {
+    // Arrange
+    const categoryParams = {
+      name: "New Category",
+      userId: 1,
+    };
+
+    // Act
+    const result = await createCategoryUseCase.execute(categoryParams);
+
+    // Assert
+    expect(result).toEqual({
+      category: {
+        name: categoryParams.name,
+      },
+    });
+  });
+
+  it("should return 'Category already exists' if the category already exists", async () => {
+    // Arrange
+    const categoryParams = {
+      name: "Existing Category",
+      userId: 1,
+    };
+    await createCategoryUseCase.execute(categoryParams);
+
+    // Act
+    const result = await createCategoryUseCase.execute(categoryParams);
+
+    // Assert
+    expect(result).toBe("Category already exists");
+  });
+});

--- a/backend/test/category/useCases/getCategoriesUseCase.spec.ts
+++ b/backend/test/category/useCases/getCategoriesUseCase.spec.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { GetCategoriesByUserUseCase } from "@/application/useCases/category/getCategoriesUseCase";
+import { InMemoryCategoryRepository } from "@/infrastructure/database/inMemoryRepository/inMemoryCategoryRepository";
+
+describe("GetCategoriesByUserUseCase", () => {
+  let getCategoriesByUserUseCase: GetCategoriesByUserUseCase;
+  let inMemoryCategoryRepository: InMemoryCategoryRepository;
+
+  beforeEach(() => {
+    inMemoryCategoryRepository = new InMemoryCategoryRepository();
+    getCategoriesByUserUseCase = new GetCategoriesByUserUseCase(
+      inMemoryCategoryRepository,
+    );
+  });
+
+  it("should return categories for a valid user ID", async () => {
+    // Arrange
+    const userId = 1;
+    await inMemoryCategoryRepository.createCategory({
+      name: "Category 1",
+      userId,
+    });
+
+    // Act
+    const result = await getCategoriesByUserUseCase.execute(userId);
+
+    // Assert
+    expect(result).toEqual({
+      categories: [{ name: "Category 1" }],
+    });
+  });
+
+  it("should return an empty array if no categories are found for the user", async () => {
+    // Arrange
+    const userId = 1;
+
+    // Act
+    const result = await getCategoriesByUserUseCase.execute(userId);
+
+    // Assert
+    expect(result).toEqual({
+      categories: [],
+    });
+  });
+});


### PR DESCRIPTION
Este pull request foca na adição de testes unitários para os casos de uso e controladores relacionados a categorias. Os testes garantem que as funcionalidades de criação de categorias e recuperação de categorias por usuário estão funcionando corretamente e lidam com vários cenários, incluindo sucesso, falhas de validação e exceções.

### Testes Unitários para Controladores:

* [`backend/test/category/controllers/createCategoryController.spec.ts`]: Adicionados testes para o `CreateCategoryController` para verificar a criação de categorias, falhas de validação e tratamento de categorias existentes e erros do servidor.
* [`backend/test/category/controllers/getCategoriesByUserController.spec.ts`]: Adicionados testes para o `GetCategoriesByUserController` para verificar a recuperação de categorias por usuário, falhas de validação e tratamento de erros do servidor.

### Testes Unitários para Casos de Uso:

* [`backend/test/category/useCases/createCategoryUseCase.spec.ts`]: Adicionados testes para o `CreateCategoryUseCase` para verificar a criação de novas categorias e o tratamento de categorias existentes.
* [`backend/test/category/useCases/getCategoriesUseCase.spec.ts`]: Adicionados testes para o `GetCategoriesByUserUseCase` para verificar a recuperação de categorias por usuário e o tratamento de cenários onde nenhuma categoria é encontrada.