### PR TITLE
feat: add the system to delete the categories

### DIFF
--- a/backend/http/category.http
+++ b/backend/http/category.http
@@ -14,3 +14,8 @@ Content-Type: application/json
 GET {{BASE_URL}}/categories
 Authorization: Bearer {{TOKEN}}
 Content-Type: application/json
+
+###
+DELETE  {{BASE_URL}}/category/49
+Authorization: Bearer {{TOKEN}}
+Content-Type: application/json

--- a/backend/src/application/interfaces/domain/entities/category/IcategoryRepository.ts
+++ b/backend/src/application/interfaces/domain/entities/category/IcategoryRepository.ts
@@ -13,4 +13,9 @@ export interface ICategoryRepository {
     name: string,
     userId: number,
   ): Promise<ICategoryWithId | null>;
+  findByIdAndUserId(
+    categoryId: number,
+    userId: number,
+  ): Promise<ICategoryWithId | null>;
+  deleteCategory(categoryId: number): Promise<void>;
 }

--- a/backend/src/application/useCases/category/deleteCategoryUseCase.ts
+++ b/backend/src/application/useCases/category/deleteCategoryUseCase.ts
@@ -1,0 +1,19 @@
+import { ICategoryRepository } from "@/application/interfaces/domain/entities/category/IcategoryRepository";
+import { IDeleteCategoryUseCase } from "@/main/config/helpers/useCases/IuseCases";
+
+export class DeleteCategoryUseCase implements IDeleteCategoryUseCase {
+  constructor(private readonly categoryRepository: ICategoryRepository) {}
+
+  async execute(categoryId: number, userId: number): Promise<void | string> {
+    const category = await this.categoryRepository.findByIdAndUserId(
+      categoryId,
+      userId,
+    );
+
+    if (!category) {
+      return "Category not found";
+    }
+
+    await this.categoryRepository.deleteCategory(categoryId);
+  }
+}

--- a/backend/src/infrastructure/database/prisma/prismaCategoryRepository.ts
+++ b/backend/src/infrastructure/database/prisma/prismaCategoryRepository.ts
@@ -43,4 +43,25 @@ export class PrismaCategoryRepository implements ICategoryRepository {
     });
     return category;
   }
+
+  async findByIdAndUserId(
+    categoryId: number,
+    userId: number,
+  ): Promise<ICategoryWithId | null> {
+    const category = await prisma.category.findFirst({
+      where: {
+        id: categoryId,
+        userId,
+      },
+    });
+    return category;
+  }
+
+  async deleteCategory(categoryId: number): Promise<void> {
+    await prisma.category.delete({
+      where: {
+        id: categoryId,
+      },
+    });
+  }
 }

--- a/backend/src/main/config/dependencyInjection/categoryDependencyInjection.ts
+++ b/backend/src/main/config/dependencyInjection/categoryDependencyInjection.ts
@@ -1,11 +1,14 @@
 import { CreateCategoryController } from "@/main/controllers/category/createCategoryController";
 import { CreateCategoryUseCase } from "@/application/useCases/category/createCategoryUseCase";
+import { DeleteCategoryController } from "@/main/controllers/category/deleteCategoryController";
+import { DeleteCategoryUseCase } from "@/application/useCases/category/deleteCategoryUseCase";
 import { GetCategoriesByUserController } from "@/main/controllers/category/getCategoriesByUserController";
 import { GetCategoriesByUserUseCase } from "@/application/useCases/category/getCategoriesUseCase";
 import { PrismaCategoryRepository } from "@/infrastructure/database/prisma/prismaCategoryRepository";
 
 const prismaCategoryRepository = new PrismaCategoryRepository();
 
+// Create
 const createCategoryUseCase = new CreateCategoryUseCase(
   prismaCategoryRepository,
 );
@@ -13,6 +16,7 @@ const createCategoryController = new CreateCategoryController(
   createCategoryUseCase,
 );
 
+// Get
 const getCategoriesByUserUseCase = new GetCategoriesByUserUseCase(
   prismaCategoryRepository,
 );
@@ -20,4 +24,16 @@ const getCategoriesByUserController = new GetCategoriesByUserController(
   getCategoriesByUserUseCase,
 );
 
-export { createCategoryController, getCategoriesByUserController };
+// Delete
+const deleteCategoryUseCase = new DeleteCategoryUseCase(
+  prismaCategoryRepository,
+);
+const deleteCategoryController = new DeleteCategoryController(
+  deleteCategoryUseCase,
+);
+
+export {
+  createCategoryController,
+  getCategoriesByUserController,
+  deleteCategoryController,
+};

--- a/backend/src/main/config/helpers/useCases/IuseCases.ts
+++ b/backend/src/main/config/helpers/useCases/IuseCases.ts
@@ -9,8 +9,8 @@ import {
 
 import { CreateCategoryParams } from "@/application/interfaces/domain/entities/category/IcategoryRepository";
 import { CreateCategoryReturn } from "@/main/config/helpers/protocol/category/createCategoryProtocols";
-import { GetCategoryByUserIdReturn } from "@/main/config/helpers/protocol/category/getCategoryProtocols";
 import { DeleteUserReturn } from "../protocol/user/deleteUserProtocols";
+import { GetCategoryByUserIdReturn } from "@/main/config/helpers/protocol/category/getCategoryProtocols";
 
 export interface ICreateUserUseCase {
   execute(params: CreateUserParams): Promise<CreateUserReturn | string>;
@@ -30,4 +30,8 @@ export interface IGetCategoriesByUserUseCase {
 
 export interface IDeleteUserUseCase {
   execute(id: number): Promise<DeleteUserReturn | string>;
+}
+
+export interface IDeleteCategoryUseCase {
+  execute(categoryId: number, userId: number): Promise<void | string>;
 }

--- a/backend/src/main/controllers/category/deleteCategoryController.ts
+++ b/backend/src/main/controllers/category/deleteCategoryController.ts
@@ -1,0 +1,49 @@
+import {
+  HttpRequest,
+  HttpResponse,
+  IController,
+} from "@/main/config/helpers/protocol/protocols";
+import {
+  badRequest,
+  niceRequest,
+  serverError,
+} from "@/main/config/helpers/helpers";
+
+import { IDeleteCategoryUseCase } from "@/main/config/helpers/useCases/IuseCases";
+import { log } from "@/main/config/logs/log";
+
+const logger = log("DeleteCategoryController");
+
+export class DeleteCategoryController implements IController {
+  constructor(private readonly deleteCategoryUseCase: IDeleteCategoryUseCase) {}
+
+  async handle(
+    httpRequest: HttpRequest<string>,
+  ): Promise<HttpResponse<string>> {
+    try {
+      const categoryId = Number(httpRequest.params.id);
+      const userId = httpRequest.userId;
+
+      logger.debug(
+        `Delete category attempt: ${categoryId} and ${typeof categoryId}`,
+      );
+
+      if (!categoryId) {
+        return badRequest("Category ID is required");
+      }
+
+      const result = await this.deleteCategoryUseCase.execute(
+        categoryId,
+        userId,
+      );
+
+      if (typeof result === "string") {
+        return badRequest(result);
+      }
+
+      return niceRequest("Category successfully deleted");
+    } catch {
+      return serverError();
+    }
+  }
+}

--- a/backend/src/main/routes/category/categoryRoutes.ts
+++ b/backend/src/main/routes/category/categoryRoutes.ts
@@ -1,4 +1,8 @@
-import { createCategory, getCategoriesByUser } from "./categoryServiceRoutes";
+import {
+  createCategory,
+  deleteCategory,
+  getCategoriesByUser,
+} from "./categoryServiceRoutes";
 
 import { authMiddleware } from "@/main/middlewares/authMiddleware";
 import express from "express";
@@ -7,5 +11,6 @@ const categoryRoutes = express.Router();
 
 categoryRoutes.post("/category", authMiddleware, createCategory);
 categoryRoutes.get("/categories", authMiddleware, getCategoriesByUser);
+categoryRoutes.delete("/category/:id", authMiddleware, deleteCategory);
 
 export default categoryRoutes;

--- a/backend/src/main/routes/category/categoryServiceRoutes.ts
+++ b/backend/src/main/routes/category/categoryServiceRoutes.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import {
   createCategoryController,
+  deleteCategoryController,
   getCategoriesByUserController,
 } from "@/main/config/dependencyInjection/categoryDependencyInjection";
 
@@ -19,6 +20,17 @@ export async function getCategoriesByUser(
   res: Response,
 ): Promise<void> {
   const { body, statusCode } = await getCategoriesByUserController.handle({
+    userId: req.userId,
+  });
+  res.status(statusCode).send(body);
+}
+
+export async function deleteCategory(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { body, statusCode } = await deleteCategoryController.handle({
+    params: req.params,
     userId: req.userId,
   });
   res.status(statusCode).send(body);


### PR DESCRIPTION
Este pull request introduz uma funcionalidade para deletar categorias na aplicação backend. As mudanças incluem a adição de novos métodos ao repositório, criação de um caso de uso e controlador para a operação de exclusão, e atualização das rotas para lidar com requisições de exclusão.

### Nova Funcionalidade: Deletar Categoria

* [`backend/src/application/interfaces/domain/entities/category/IcategoryRepository.ts`]: Adicionados os métodos `findByIdAndUserId` e `deleteCategory` na interface `ICategoryRepository`.
* [`backend/src/application/useCases/category/deleteCategoryUseCase.ts`]: Implementada a classe `DeleteCategoryUseCase` para lidar com a lógica de negócio para excluir uma categoria.
* [`backend/src/infrastructure/database/prisma/prismaCategoryRepository.ts`]: Adicionadas implementações para os métodos `findByIdAndUserId` e `deleteCategory` na classe `PrismaCategoryRepository`.
* [`backend/src/main/controllers/category/deleteCategoryController.ts`]: Criada a classe `DeleteCategoryController` para lidar com requisições HTTP para excluir uma categoria.
* [`backend/src/main/routes/category/categoryRoutes.ts`]: Atualizadas as rotas para incluir um endpoint de exclusão para categorias. 

### Injeção de Dependência e Helpers

* [`backend/src/main/config/dependencyInjection/categoryDependencyInjection.ts`]: Configurada a injeção de dependência para o caso de uso e controlador de exclusão de categoria.
* [`backend/src/main/config/helpers/useCases/IuseCases.ts`]: Adicionada a interface `IDeleteCategoryUseCase` para definir o contrato do caso de uso de exclusão de categoria.

### Rotas HTTP e de Serviço

* [`backend/http/category.http`]: Adicionado um exemplo de requisição HTTP para excluir uma categoria.
* [`backend/src/main/routes/category/categoryServiceRoutes.ts`]: Adicionada uma função de rota de serviço para lidar com requisições de exclusão de categoria.