### PR TITLE
test: add unit tests to delete the user

### DIFF
--- a/backend/src/infrastructure/database/inMemoryRepository/inMemoryAuthUserRepository.ts
+++ b/backend/src/infrastructure/database/inMemoryRepository/inMemoryAuthUserRepository.ts
@@ -14,8 +14,21 @@ export class InMemoryAuthUserRepository implements IAuthUserRepository {
     return newUser;
   }
 
+  async findUserById(id: number): Promise<IUserWithId | null> {
+    const user = this.users.find((user) => user.id === id);
+    return user || null;
+  }
+
   async findUserByEmail(email: string): Promise<IUserWithId | null> {
     const user = this.users.find((user) => user.email === email);
     return user || null;
+  }
+
+  async deleteUser(id: number): Promise<undefined> {
+    const index = this.users.findIndex((user) => user.id === id);
+    if (index !== -1) {
+      this.users.splice(index, 1);
+    }
+    return undefined;
   }
 }

--- a/backend/test/user/controllers/deleteUserController.spec.ts
+++ b/backend/test/user/controllers/deleteUserController.spec.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DeleteUserController } from "@/main/controllers/user/deleteUserController";
+import { DeleteUserUseCase } from "@/application/useCases/deleteUserUseCase";
+import { HttpRequest } from "@/main/config/helpers/protocol/protocols";
+import { InMemoryAuthUserRepository } from "@/infrastructure/database/inMemoryRepository/inMemoryAuthUserRepository";
+
+describe("DeleteUserController", () => {
+  let deleteUserController: DeleteUserController;
+  let deleteUserUseCase: DeleteUserUseCase;
+  let inMemoryAuthUserRepository: InMemoryAuthUserRepository;
+
+  beforeEach(() => {
+    inMemoryAuthUserRepository = new InMemoryAuthUserRepository();
+    deleteUserUseCase = new DeleteUserUseCase(inMemoryAuthUserRepository);
+    deleteUserController = new DeleteUserController(deleteUserUseCase);
+  });
+
+  it("should delete a user and return a nice request response", async () => {
+    // Arrange
+    const userParams = {
+      name: "John Doe",
+      email: "john.doe@example.com",
+      password: "password",
+    };
+    const user = await inMemoryAuthUserRepository.createUser(userParams);
+    const httpRequest: HttpRequest<unknown> = {
+      body: user.id,
+    };
+
+    // Act
+    const httpResponse = await deleteUserController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(200);
+    expect(httpResponse.body).toEqual({
+      message: "User successfully deleted",
+      user: {
+        name: user.name,
+        email: user.email,
+      },
+    });
+  });
+
+  it("should return bad request if user ID is not provided", async () => {
+    // Arrange
+    const httpRequest: HttpRequest<unknown> = {
+      body: null,
+    };
+
+    // Act
+    const httpResponse = await deleteUserController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(400);
+    expect(httpResponse.body).toBe("UserId are required");
+  });
+
+  it("should return bad request if user does not exist", async () => {
+    // Arrange
+    const httpRequest: HttpRequest<unknown> = {
+      body: 999,
+    };
+
+    // Act
+    const httpResponse = await deleteUserController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(400);
+    expect(httpResponse.body).toBe("User not found");
+  });
+
+  it("should return server error if an exception is thrown", async () => {
+    // Arrange
+    const httpRequest: HttpRequest<unknown> = {
+      body: 1,
+    };
+    vi.spyOn(deleteUserUseCase, "execute").mockRejectedValueOnce(new Error(""));
+
+    // Act
+    const httpResponse = await deleteUserController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(500);
+    expect(httpResponse.body).toBe("Something went wrong.");
+  });
+});

--- a/backend/test/user/useCases/deleteUserUseCase.spec.ts
+++ b/backend/test/user/useCases/deleteUserUseCase.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { DeleteUserUseCase } from "@/application/useCases/deleteUserUseCase";
+import { InMemoryAuthUserRepository } from "@/infrastructure/database/inMemoryRepository/inMemoryAuthUserRepository";
+
+describe("DeleteUserUseCase", () => {
+  let deleteUserUseCase: DeleteUserUseCase;
+  let inMemoryAuthUserRepository: InMemoryAuthUserRepository;
+
+  beforeEach(() => {
+    inMemoryAuthUserRepository = new InMemoryAuthUserRepository();
+    deleteUserUseCase = new DeleteUserUseCase(inMemoryAuthUserRepository);
+  });
+
+  it("should delete a user if they exist", async () => {
+    // Arrange
+    const userParams = {
+      name: "John Doe",
+      email: "john.doe@example.com",
+      password: "password",
+    };
+    const user = await inMemoryAuthUserRepository.createUser(userParams);
+
+    // Act
+    const result = await deleteUserUseCase.execute(user.id);
+
+    // Assert
+    expect(result).toEqual({
+      user: {
+        name: user.name,
+        email: user.email,
+      },
+    });
+    const deletedUser = await inMemoryAuthUserRepository.findUserById(user.id);
+    expect(deletedUser).toBeNull();
+  });
+
+  it("should return 'User not found' if the user does not exist", async () => {
+    // Act
+    const result = await deleteUserUseCase.execute(999);
+
+    // Assert
+    expect(result).toBe("User not found");
+  });
+});


### PR DESCRIPTION
Este pull request introduz a funcionalidade de exclusão de usuários no `InMemoryAuthUserRepository` e inclui testes correspondentes para a nova funcionalidade. As mudanças mais importantes incluem a adição do método `deleteUser`, novos casos de teste para o `DeleteUserController` e casos de teste para o `DeleteUserUseCase`.

### Nova funcionalidade:

- Adicionado o método `deleteUser` no `InMemoryAuthUserRepository` para permitir a exclusão de usuários por ID.

### Novos testes:

- Adicionados casos de teste para `deleteUser` em `deleteUserController.spec.ts` para garantir o tratamento adequado da exclusão de usuários, incluindo ausência de ID, usuário inexistente e erros de servidor.
- Adicionados casos de teste para `deleteUser` em `deleteUserUseCase.spec.ts` para verificar a exclusão de usuários e o tratamento de usuários inexistentes.