### PR TITLE
test: add unit tests to exclude categories

### DIFF
--- a/backend/src/domain/entities/Category.ts
+++ b/backend/src/domain/entities/Category.ts
@@ -6,10 +6,3 @@ export interface ICategory {
 export interface ICategoryWithId extends ICategory {
   id: number;
 }
-
-export class Category {
-  constructor(
-    public readonly name: string,
-    private readonly userId: number,
-  ) {}
-}

--- a/backend/src/infrastructure/database/inMemoryRepository/inMemoryCategoryRepository.ts
+++ b/backend/src/infrastructure/database/inMemoryRepository/inMemoryCategoryRepository.ts
@@ -1,13 +1,14 @@
 import {
   CreateCategoryParams,
   ICategoryRepository,
+  UpdateCategoryParams,
 } from "@/application/interfaces/domain/entities/category/IcategoryRepository";
 
 import { ICategoryWithId } from "@/domain/entities/Category";
 
 export class InMemoryCategoryRepository implements ICategoryRepository {
-  private categories: ICategoryWithId[] = [];
   private currentId = 1;
+  private categories: ICategoryWithId[] = [];
 
   async createCategory(params: CreateCategoryParams): Promise<ICategoryWithId> {
     const newCategory: ICategoryWithId = {
@@ -35,5 +36,36 @@ export class InMemoryCategoryRepository implements ICategoryRepository {
       (category) => category.name === name && category.userId === userId,
     );
     return category || null;
+  }
+
+  async findByIdAndUserId(
+    categoryId: number,
+    userId: number,
+  ): Promise<ICategoryWithId | null> {
+    const category = this.categories.find(
+      (category) => category.id === categoryId && category.userId === userId,
+    );
+    return category || null;
+  }
+
+  async updateCategory(
+    category: UpdateCategoryParams,
+  ): Promise<ICategoryWithId> {
+    const index = this.categories.findIndex((cat) => cat.id === category.id);
+    if (index === -1) {
+      throw new Error("Category not found.");
+    }
+    this.categories[index] = { ...this.categories[index], ...category };
+    return this.categories[index];
+  }
+
+  async deleteCategory(categoryId: number): Promise<void> {
+    const index = this.categories.findIndex(
+      (category) => category.id === categoryId,
+    );
+    if (index === -1) {
+      throw new Error("Category not found.");
+    }
+    this.categories.splice(index, 1);
   }
 }

--- a/backend/test/category/controllers/deleteCategoryController.spec.ts
+++ b/backend/test/category/controllers/deleteCategoryController.spec.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DeleteCategoryController } from "@/main/controllers/category/deleteCategoryController";
+import { DeleteCategoryUseCase } from "@/application/useCases/category/deleteCategoryUseCase";
+import { HttpRequest } from "@/main/config/helpers/protocol/protocols";
+import { InMemoryCategoryRepository } from "@/infrastructure/database/inMemoryRepository/inMemoryCategoryRepository";
+
+describe("DeleteCategoryController", () => {
+  let deleteCategoryController: DeleteCategoryController;
+  let deleteCategoryUseCase: DeleteCategoryUseCase;
+  let inMemoryCategoryRepository: InMemoryCategoryRepository;
+
+  beforeEach(() => {
+    inMemoryCategoryRepository = new InMemoryCategoryRepository();
+    deleteCategoryUseCase = new DeleteCategoryUseCase(
+      inMemoryCategoryRepository,
+    );
+    deleteCategoryController = new DeleteCategoryController(
+      deleteCategoryUseCase,
+    );
+  });
+
+  it("should delete a category and return a nice request response", async () => {
+    // Arrange
+    const categoryParams = { name: "Category to delete", userId: 1 };
+    const category =
+      await inMemoryCategoryRepository.createCategory(categoryParams);
+    const httpRequest: HttpRequest<string> = {
+      params: { id: category.id.toString() },
+      userId: category.userId,
+    };
+
+    // Act
+    const httpResponse = await deleteCategoryController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(200);
+    expect(httpResponse.body).toBe("Category successfully deleted");
+  });
+
+  it("should return bad request if category ID is not provided", async () => {
+    // Arrange
+    const httpRequest: HttpRequest<string> = {
+      params: {},
+      userId: 1,
+    };
+
+    // Act
+    const httpResponse = await deleteCategoryController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(400);
+    expect(httpResponse.body).toBe("Category ID is required");
+  });
+
+  it("should return bad request if category does not exist", async () => {
+    // Arrange
+    const httpRequest: HttpRequest<string> = {
+      params: { id: "999" },
+      userId: 1,
+    };
+
+    // Act
+    const httpResponse = await deleteCategoryController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(400);
+    expect(httpResponse.body).toBe("Category not found");
+  });
+
+  it("should return server error if an exception is thrown", async () => {
+    // Arrange
+    const httpRequest: HttpRequest<string> = {
+      params: { id: "1" },
+      userId: 1,
+    };
+    vi.spyOn(deleteCategoryUseCase, "execute").mockRejectedValueOnce(
+      new Error(""),
+    );
+
+    // Act
+    const httpResponse = await deleteCategoryController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(500);
+    expect(httpResponse.body).toBe("Something went wrong.");
+  });
+});

--- a/backend/test/category/useCases/deleteCategoryUseCase.spec.ts
+++ b/backend/test/category/useCases/deleteCategoryUseCase.spec.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { DeleteCategoryUseCase } from "@/application/useCases/category/deleteCategoryUseCase";
+import { InMemoryCategoryRepository } from "@/infrastructure/database/inMemoryRepository/inMemoryCategoryRepository";
+
+describe("DeleteCategoryUseCase", () => {
+  let deleteCategoryUseCase: DeleteCategoryUseCase;
+  let inMemoryCategoryRepository: InMemoryCategoryRepository;
+
+  beforeEach(() => {
+    inMemoryCategoryRepository = new InMemoryCategoryRepository();
+    deleteCategoryUseCase = new DeleteCategoryUseCase(
+      inMemoryCategoryRepository,
+    );
+  });
+
+  it("should delete a category if it exists", async () => {
+    // Arrange
+    const categoryParams = { name: "Category to delete", userId: 1 };
+    const category =
+      await inMemoryCategoryRepository.createCategory(categoryParams);
+
+    // Act
+    const result = await deleteCategoryUseCase.execute(
+      category.id,
+      category.userId,
+    );
+
+    // Assert
+    expect(result).toBeUndefined();
+    const deletedCategory = await inMemoryCategoryRepository.findByIdAndUserId(
+      category.id,
+      category.userId,
+    );
+    expect(deletedCategory).toBeNull();
+  });
+
+  it("should return 'Category not found' if the category does not exist", async () => {
+    // Act
+    const result = await deleteCategoryUseCase.execute(999, 1);
+
+    // Assert
+    expect(result).toBe("Category not found");
+  });
+
+  it("should return 'Category not found' if the category does not belong to the user", async () => {
+    // Arrange
+    const categoryParams = { name: "Category to delete", userId: 1 };
+    const category =
+      await inMemoryCategoryRepository.createCategory(categoryParams);
+
+    // Act
+    const result = await deleteCategoryUseCase.execute(category.id, 2);
+
+    // Assert
+    expect(result).toBe("Category not found");
+  });
+});


### PR DESCRIPTION
Este pull request introduz várias alterações no sistema de gerenciamento de categorias, incluindo a adição de novas funcionalidades e testes correspondentes. As mudanças mais importantes incluem a remoção da classe `Category`, atualizações no `InMemoryCategoryRepository` e a adição de novos testes para o `DeleteCategoryController` e o `DeleteCategoryUseCase`.

### Alterações no código:

- [`backend/src/domain/entities/Category.ts`]: Removida a classe `Category`.
- [`backend/src/infrastructure/database/inMemoryRepository/inMemoryCategoryRepository.ts`]: Adicionados métodos para buscar, atualizar e deletar categorias por ID e ID de usuário.

### Melhorias nos testes:

- [`backend/test/category/controllers/deleteCategoryController.spec.ts`]: Adicionados testes para o `DeleteCategoryController` para garantir o manejo correto da exclusão de categorias, incluindo casos extremos.
- [`backend/test/category/useCases/deleteCategoryUseCase.spec.ts`]: Adicionados testes para o `DeleteCategoryUseCase` para verificar o comportamento correto de exclusão e o tratamento de categorias inexistentes ou não autorizadas.