### PR TITLE
test: add unit tests to update categories

### DIFF
--- a/backend/test/category/controllers/updateCategoryController.spec.ts
+++ b/backend/test/category/controllers/updateCategoryController.spec.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HttpRequest } from "@/main/config/helpers/protocol/protocols";
+import { InMemoryCategoryRepository } from "@/infrastructure/database/inMemoryRepository/inMemoryCategoryRepository";
+import { UpdateCategoryController } from "@/main/controllers/category/updateCategoryController";
+import { UpdateCategoryParams } from "@/application/interfaces/domain/entities/category/IcategoryRepository";
+import { UpdateCategoryUseCase } from "@/application/useCases/category/updateCategoryUseCase";
+
+describe("UpdateCategoryController", () => {
+  let updateCategoryController: UpdateCategoryController;
+  let updateCategoryUseCase: UpdateCategoryUseCase;
+  let inMemoryCategoryRepository: InMemoryCategoryRepository;
+
+  beforeEach(() => {
+    inMemoryCategoryRepository = new InMemoryCategoryRepository();
+    updateCategoryUseCase = new UpdateCategoryUseCase(
+      inMemoryCategoryRepository,
+    );
+    updateCategoryController = new UpdateCategoryController(
+      updateCategoryUseCase,
+    );
+  });
+
+  it("should update a category and return a nice request response", async () => {
+    // Arrange
+    const categoryParams = { name: "Category to update", userId: 1 };
+    const category =
+      await inMemoryCategoryRepository.createCategory(categoryParams);
+    const httpRequest: HttpRequest<UpdateCategoryParams> = {
+      params: { id: category.id.toString() },
+      body: {
+        id: category.id,
+        name: "Updated Category",
+        userId: category.userId,
+      },
+    };
+
+    // Act
+    const httpResponse = await updateCategoryController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(200);
+    expect(httpResponse.body).toEqual({
+      message: "Category updated successfully",
+      category: {
+        name: "Updated Category",
+      },
+    });
+  });
+
+  it("should return bad request if category ID is not provided", async () => {
+    // Arrange
+    const httpRequest: HttpRequest<UpdateCategoryParams> = {
+      params: {},
+      body: { id: 1, name: "Updated Category", userId: 1 },
+    };
+
+    // Act
+    const httpResponse = await updateCategoryController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(400);
+    expect(httpResponse.body).toBe("Category not found");
+  });
+
+  it("should return bad request if category does not exist", async () => {
+    // Arrange
+    const httpRequest: HttpRequest<UpdateCategoryParams> = {
+      params: { id: "999" },
+      body: { id: 999, name: "Non-existent Category", userId: 1 },
+    };
+
+    // Act
+    const httpResponse = await updateCategoryController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(400);
+    expect(httpResponse.body).toBe("Category not found");
+  });
+
+  it("should return server error if an exception is thrown", async () => {
+    // Arrange
+    const httpRequest: HttpRequest<UpdateCategoryParams> = {
+      params: { id: "1" },
+      body: { id: 1, name: "Updated Category", userId: 1 },
+    };
+    vi.spyOn(updateCategoryUseCase, "execute").mockRejectedValueOnce(
+      new Error(""),
+    );
+
+    // Act
+    const httpResponse = await updateCategoryController.handle(httpRequest);
+
+    // Assert
+    expect(httpResponse.statusCode).toBe(500);
+    expect(httpResponse.body).toBe("Something went wrong.");
+  });
+});

--- a/backend/test/category/useCases/updateCategoryUseCase.spec.ts
+++ b/backend/test/category/useCases/updateCategoryUseCase.spec.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { InMemoryCategoryRepository } from "@/infrastructure/database/inMemoryRepository/inMemoryCategoryRepository";
+import { UpdateCategoryUseCase } from "@/application/useCases/category/updateCategoryUseCase";
+
+describe("UpdateCategoryUseCase", () => {
+  let updateCategoryUseCase: UpdateCategoryUseCase;
+  let inMemoryCategoryRepository: InMemoryCategoryRepository;
+
+  beforeEach(() => {
+    inMemoryCategoryRepository = new InMemoryCategoryRepository();
+    updateCategoryUseCase = new UpdateCategoryUseCase(
+      inMemoryCategoryRepository,
+    );
+  });
+
+  it("should update a category if it exists", async () => {
+    // Arrange
+    const categoryParams = { name: "Category to update", userId: 1 };
+    const category =
+      await inMemoryCategoryRepository.createCategory(categoryParams);
+    const updateParams = {
+      id: category.id,
+      name: "Updated Category",
+      userId: category.userId,
+    };
+
+    // Act
+    const result = await updateCategoryUseCase.execute(updateParams);
+
+    // Assert
+    expect(result).toEqual({
+      category: {
+        name: updateParams.name,
+      },
+    });
+    const updatedCategory = await inMemoryCategoryRepository.findByIdAndUserId(
+      category.id,
+      category.userId,
+    );
+    expect(updatedCategory?.name).toBe(updateParams.name);
+  });
+
+  it("should return 'Category not found' if the category does not exist", async () => {
+    // Arrange
+    const updateParams = { id: 999, name: "Non-existent Category", userId: 1 };
+
+    // Act
+    const result = await updateCategoryUseCase.execute(updateParams);
+
+    // Assert
+    expect(result).toBe("Category not found");
+  });
+
+  it("should return 'Category not found' if the category does not belong to the user", async () => {
+    // Arrange
+    const categoryParams = { name: "Category to update", userId: 1 };
+    const category =
+      await inMemoryCategoryRepository.createCategory(categoryParams);
+    const updateParams = {
+      id: category.id,
+      name: "Updated Category",
+      userId: 2,
+    };
+
+    // Act
+    const result = await updateCategoryUseCase.execute(updateParams);
+
+    // Assert
+    expect(result).toBe("Category not found");
+  });
+});


### PR DESCRIPTION
Este pull request introduz novos casos de teste para as classes `UpdateCategoryController` e `UpdateCategoryUseCase` a fim de garantir a funcionalidade adequada e o tratamento correto de erros. As mudanças mais importantes incluem a adição de novos arquivos de teste e a definição de diversos cenários de teste.

Novos casos de teste para `UpdateCategoryController`:

- [`backend/test/category/controllers/updateCategoryController.spec.ts`]: Adicionados testes para verificar a atualização bem-sucedida de categorias, o tratamento de ID de categoria ausente, o tratamento de categoria inexistente e o tratamento de exceções.

Novos casos de teste para `UpdateCategoryUseCase`:

- [`backend/test/category/useCases/updateCategoryUseCase.spec.ts`]: Adicionados testes para verificar a atualização bem-sucedida de categorias e o tratamento de categorias inexistentes.